### PR TITLE
Update: added dashboard capability and avalibility statuses.

### DIFF
--- a/cypress/e2e/jaydon-flows.cy.js
+++ b/cypress/e2e/jaydon-flows.cy.js
@@ -4,25 +4,35 @@ describe("Jaydon assigned pet adoption flows", () => {
   });
 
   it("opens a pet profile from discovery and favorites, then submits an adoption inquiry", () => {
+    const adopterName = `Jaydon Test ${Date.now()}`;
+    let selectedPetName = "";
+
     cy.visit("/");
     cy.contains("Pet Adoption Match");
-    cy.get("[data-cy=pet-card]").first().within(() => {
-      cy.get("[data-cy=pet-card-link]").click();
+    cy.get("[data-cy=pet-card]").first().find("h3").then(($heading) => {
+      selectedPetName = $heading.text();
     });
+    cy.get("[data-cy=pet-card]").first().find("[data-cy=pet-card-link]").click();
 
-    cy.get("[data-cy=pet-profile-name]").should("contain.text", "Luna");
-    cy.get("[data-cy=pet-gallery]").find("[data-cy=pet-photo-thumb]").should("have.length.at.least", 2);
+    cy.then(() => {
+      cy.get("[data-cy=pet-profile-name]").should("contain.text", selectedPetName);
+    });
+    cy.get("[data-cy=pet-gallery]").find("[data-cy=pet-photo-thumb]").should("have.length.at.least", 1);
     cy.get("[data-cy=save-pet]").click().should("contain.text", "Saved pet");
     cy.get("[data-cy=start-inquiry]").should("be.visible");
 
     cy.visit("/#/favorites");
-    cy.get("[data-cy=favorites-list]").should("contain.text", "Luna");
+    cy.then(() => {
+      cy.get("[data-cy=favorites-list]").should("contain.text", selectedPetName);
+    });
     cy.get("[data-cy=favorite-pet-card]").first().within(() => {
       cy.get("[data-cy=favorite-profile-link]").click();
     });
-    cy.get("[data-cy=pet-profile-name]").should("contain.text", "Luna");
+    cy.then(() => {
+      cy.get("[data-cy=pet-profile-name]").should("contain.text", selectedPetName);
+    });
 
-    cy.get("[data-cy=inquiry-name]").type("Jaydon Test");
+    cy.get("[data-cy=inquiry-name]").type(adopterName);
     cy.get("[data-cy=inquiry-email]").type("jaydon@example.com");
     cy.get("[data-cy=inquiry-phone]").type("555-123-4567");
     cy.get("[data-cy=inquiry-housing]").type("Apartment with landlord approval and a nearby park.");
@@ -32,9 +42,11 @@ describe("Jaydon assigned pet adoption flows", () => {
     cy.get("[data-cy=inquiry-success]").should("contain.text", "Inquiry sent");
 
     cy.visit("/#/shelter");
-    cy.get("[data-cy=inquiry-list]").should("contain.text", "Jaydon Test");
-    cy.contains("[data-cy=inquiry-item]", "Jaydon Test").within(() => {
-      cy.contains("Luna");
+    cy.get("[data-cy=inquiry-list]").should("contain.text", adopterName);
+    cy.contains("[data-cy=inquiry-item]", adopterName).within(() => {
+      cy.then(() => {
+        cy.contains(selectedPetName);
+      });
       cy.contains("jaydon@example.com");
       cy.contains("555-123-4567");
       cy.contains("Apartment with landlord approval and a nearby park.");
@@ -43,7 +55,7 @@ describe("Jaydon assigned pet adoption flows", () => {
     });
     cy.get("[data-cy=inquiry-status-message]").should("contain.text", "marked contacted");
     cy.reload();
-    cy.contains("[data-cy=inquiry-item]", "Jaydon Test").within(() => {
+    cy.contains("[data-cy=inquiry-item]", adopterName).within(() => {
       cy.get("[data-cy=inquiry-status-select]").should("have.value", "contacted");
     });
   });

--- a/cypress/e2e/jaydon-flows.cy.js
+++ b/cypress/e2e/jaydon-flows.cy.js
@@ -30,6 +30,22 @@ describe("Jaydon assigned pet adoption flows", () => {
     cy.get("[data-cy=submit-inquiry]").click();
 
     cy.get("[data-cy=inquiry-success]").should("contain.text", "Inquiry sent");
+
+    cy.visit("/#/shelter");
+    cy.get("[data-cy=inquiry-list]").should("contain.text", "Jaydon Test");
+    cy.contains("[data-cy=inquiry-item]", "Jaydon Test").within(() => {
+      cy.contains("Luna");
+      cy.contains("jaydon@example.com");
+      cy.contains("555-123-4567");
+      cy.contains("Apartment with landlord approval and a nearby park.");
+      cy.contains("I am interested in meeting this pet this week.");
+      cy.get("[data-cy=inquiry-status-select]").should("have.value", "new").select("contacted");
+    });
+    cy.get("[data-cy=inquiry-status-message]").should("contain.text", "marked contacted");
+    cy.reload();
+    cy.contains("[data-cy=inquiry-item]", "Jaydon Test").within(() => {
+      cy.get("[data-cy=inquiry-status-select]").should("have.value", "contacted");
+    });
   });
 
   it("creates a pet, manages multiple photos, and shows updates in discovery", () => {

--- a/packages/express-backend/models/inquiry.js
+++ b/packages/express-backend/models/inquiry.js
@@ -1,52 +1,58 @@
 import mongoose from "mongoose";
 
+const inquiryStatuses = ["new", "contacted", "approved", "rejected"];
+
 const InquirySchema = new mongoose.Schema(
   {
     user: {
-          type: mongoose.Schema.Types.ObjectId,
-          ref: "User",
-        },
-    pet: {
-        type: mongoose.Schema.Types.ObjectId,
-        ref: "Pet",
-      },
-    petId: {
-      type: String,
-      trim: true,
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User"
     },
-    petName: {
-      type: String,
-      trim: true,
+    pet: {
+      type: mongoose.Schema.Types.ObjectId,
+      required: true,
+      ref: "Pet"
     },
     name: {
       type: String,
-      trim: true,
+      required() {
+        return !this.user;
+      },
+      trim: true
     },
     email: {
       type: String,
-      trim: true,
+      lowercase: true,
+      required() {
+        return !this.user;
+      },
+      trim: true
     },
     phone: {
       type: String,
-      trim: true,
+      required: true,
+      trim: true
     },
     housing: {
       type: String,
-      trim: true,
+      required: true,
+      trim: true
     },
     message: {
       type: String,
-      trim: true,
+      required: true,
+      trim: true
     },
     date: {
       type: Date,
       default: Date.now,
+      required: true
     },
     status: {
       type: String,
-      enum: ["new", "contacted", "approved", "rejected"],
+      enum: inquiryStatuses,
       default: "new"
-    },
+    }
   },
   {
     collection: "inquiries",

--- a/packages/express-backend/routes/inquiry-routes.js
+++ b/packages/express-backend/routes/inquiry-routes.js
@@ -4,7 +4,15 @@ import express from "express";
 const router = express.Router();
 import inquiryService from "../services/inquiry-service.js";
 
-const { addInquiry, getInquiries, findInquiryById, removeInquiry } = inquiryService;
+const {
+  addInquiry,
+  getInquiries,
+  findInquiryById,
+  removeInquiry,
+  updateInquiryStatus
+} = inquiryService;
+
+const allowedStatuses = ["new", "contacted", "approved", "rejected"];
 
 router.get("/", (req, res) => {
 
@@ -22,17 +30,24 @@ router.post("/", (req, res) => {
 
   if (
     inquiryToAdd &&
-    (inquiryToAdd.pet != null || inquiryToAdd.petId != null) &&
+    inquiryToAdd.pet != null &&
     (inquiryToAdd.user != null ||
       (inquiryToAdd.name != null &&
-        inquiryToAdd.email != null &&
-        inquiryToAdd.phone != null &&
-        inquiryToAdd.housing != null &&
-        inquiryToAdd.message != null))
+        inquiryToAdd.email != null)) &&
+    inquiryToAdd.phone != null &&
+    inquiryToAdd.housing != null &&
+    inquiryToAdd.message != null
     
   ) {
     const newInquiry = {
-      ...inquiryToAdd,
+      user: inquiryToAdd.user,
+      pet: inquiryToAdd.pet,
+      name: inquiryToAdd.name,
+      email: inquiryToAdd.email,
+      phone: inquiryToAdd.phone,
+      housing: inquiryToAdd.housing,
+      message: inquiryToAdd.message,
+      status: inquiryToAdd.status,
       date: inquiryToAdd.date || new Date()
     };
     addInquiry(newInquiry)
@@ -58,6 +73,29 @@ router.delete("/:id", (req, res) => {
     .catch((error) => {
       console.log(error);
       res.status(404).send();
+    });
+});
+
+router.patch("/:id/status", (req, res) => {
+  const id = req.params["id"];
+  const { status } = req.body;
+
+  if (!allowedStatuses.includes(status)) {
+    res.status(400).send("Invalid inquiry status");
+    return;
+  }
+
+  updateInquiryStatus(id, status)
+    .then((inquiry) => {
+      if (!inquiry) {
+        res.status(404).send("Inquiry not found.");
+      } else {
+        res.send(inquiry);
+      }
+    })
+    .catch((error) => {
+      console.log(error);
+      res.status(500).send("Failed to update inquiry status");
     });
 });
 

--- a/packages/express-backend/services/inquiry-service.js
+++ b/packages/express-backend/services/inquiry-service.js
@@ -3,11 +3,13 @@ import inquiryModel from "../models/inquiry.js";
 
 function addInquiry(inquiry) {
   const inquiryToAdd = new inquiryModel(inquiry);
-  return inquiryToAdd.save();
+  return inquiryToAdd.save().then((createdInquiry) =>
+    createdInquiry.populate(["pet", "user"])
+  );
 }
 
 function getInquiries() {
-  return inquiryModel.find();
+  return inquiryModel.find().sort({ date: -1 }).populate(["pet", "user"]);
 }
 
 function removeInquiry(id) {
@@ -18,9 +20,18 @@ function findInquiryById(id) {
   return inquiryModel.findById(id);
 }
 
+function updateInquiryStatus(id, status) {
+  return inquiryModel.findByIdAndUpdate(
+    id,
+    { status },
+    { new: true, runValidators: true }
+  ).populate(["pet", "user"]);
+}
+
 export default {
   addInquiry,
   getInquiries,
   removeInquiry,
-  findInquiryById
+  findInquiryById,
+  updateInquiryStatus
 };

--- a/packages/express-backend/services/inquiry-service.js
+++ b/packages/express-backend/services/inquiry-service.js
@@ -24,7 +24,7 @@ function updateInquiryStatus(id, status) {
   return inquiryModel.findByIdAndUpdate(
     id,
     { status },
-    { new: true, runValidators: true }
+    { returnDocument: "after", runValidators: true }
   ).populate(["pet", "user"]);
 }
 

--- a/packages/express-backend/services/pet-service.js
+++ b/packages/express-backend/services/pet-service.js
@@ -22,7 +22,7 @@ function updatePetAvailability(id, availability) {
   return petModel.findByIdAndUpdate(
     id,
     { availability },
-    { new: true }
+    { returnDocument: "after" }
   );
 }
 
@@ -30,7 +30,7 @@ function updatePetPhotos(id, imageUrls) {
   return petModel.findByIdAndUpdate(
     id,
     { imageUrls },
-    { new: true, runValidators: true }
+    { returnDocument: "after", runValidators: true }
   );
 }
 

--- a/packages/react-frontend/src/MyApp.jsx
+++ b/packages/react-frontend/src/MyApp.jsx
@@ -75,6 +75,8 @@ const emptyInquiry = {
   message: ""
 };
 
+const inquiryStatuses = ["new", "contacted", "approved", "rejected"];
+
 function readJson(key, fallback) {
   try {
     const stored = window.localStorage.getItem(key);
@@ -103,6 +105,20 @@ async function apiRequest(path, options = {}) {
 
   if (response.status === 204) return null;
   return response.json();
+}
+
+function normalizeInquiry(inquiry) {
+  return {
+    ...inquiry,
+    id: inquiry.id || inquiry._id,
+    petName: inquiry.pet?.name || inquiry.petName || "Unknown pet",
+    name: inquiry.user?.name || inquiry.name || "Unknown adopter",
+    email: inquiry.user?.email || inquiry.email || "No email provided",
+    phone: inquiry.phone || "No phone provided",
+    housing: inquiry.housing || "No housing information provided",
+    message: inquiry.message || "No message provided",
+    date: inquiry.date || inquiry.createdAt || ""
+  };
 }
 
 function normalizePet(pet) {
@@ -216,6 +232,17 @@ function Field({ label, children, hint }) {
       {hint ? <small>{hint}</small> : null}
     </label>
   );
+}
+
+function formatSubmittedDate(date) {
+  const parsedDate = new Date(date);
+
+  if (Number.isNaN(parsedDate.getTime())) return "Unknown date";
+
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short"
+  }).format(parsedDate);
 }
 
 function HomePage({ pets }) {
@@ -425,9 +452,11 @@ function FavoritesPage({ pets, favoriteIds }) {
   );
 }
 
-function ShelterPage({ pets, addPet }) {
+function ShelterPage({ pets, inquiries, addPet, updateInquiryStatus }) {
   const [form, setForm] = useState(emptyPet);
   const [status, setStatus] = useState("");
+  const [inquiryStatusMessage, setInquiryStatusMessage] = useState("");
+  const [updatingInquiryId, setUpdatingInquiryId] = useState("");
 
   function updateField(field, value) {
     setForm((current) => ({ ...current, [field]: value }));
@@ -471,6 +500,20 @@ function ShelterPage({ pets, addPet }) {
       setStatus(`${createdPet.name} was created and is now visible in the discovery feed.`);
     } catch {
       setStatus("Pet profile could not be saved. Check that the backend and MongoDB are running.");
+    }
+  }
+
+  async function changeInquiryStatus(inquiry, nextStatus) {
+    setInquiryStatusMessage(`Updating ${inquiry.petName} inquiry...`);
+    setUpdatingInquiryId(inquiry.id);
+
+    try {
+      await updateInquiryStatus(inquiry.id, nextStatus);
+      setInquiryStatusMessage(`${inquiry.petName} inquiry marked ${nextStatus}.`);
+    } catch {
+      setInquiryStatusMessage("Inquiry status could not be saved. Check that the backend is running.");
+    } finally {
+      setUpdatingInquiryId("");
     }
   }
 
@@ -527,6 +570,67 @@ function ShelterPage({ pets, addPet }) {
           ))}
         </div>
       </aside>
+      <section className="panel inquiry-panel">
+        <div className="section-heading compact">
+          <div>
+            <span className="eyebrow">Adopter follow-up</span>
+            <h2>Submitted inquiries</h2>
+          </div>
+          <p>{inquiries.length} total</p>
+        </div>
+        {inquiryStatusMessage ? (
+          <div className="success" data-cy="inquiry-status-message">{inquiryStatusMessage}</div>
+        ) : null}
+        {inquiries.length === 0 ? (
+          <div className="empty-state" data-cy="inquiries-empty">
+            No adoption inquiries have been submitted yet.
+          </div>
+        ) : (
+          <div className="inquiry-list" data-cy="inquiry-list">
+            {inquiries.map((inquiry) => (
+              <article className="inquiry-item" key={inquiry.id} data-cy="inquiry-item">
+                <div className="inquiry-heading">
+                  <div>
+                    <h3>{inquiry.petName}</h3>
+                    <p>{formatSubmittedDate(inquiry.date)}</p>
+                  </div>
+                  <label className="status-control">
+                    <span>Status</span>
+                    <select
+                      value={inquiry.status || "new"}
+                      onChange={(event) => changeInquiryStatus(inquiry, event.target.value)}
+                      disabled={updatingInquiryId === inquiry.id}
+                      data-cy="inquiry-status-select"
+                    >
+                      {inquiryStatuses.map((statusOption) => (
+                        <option key={statusOption} value={statusOption}>
+                          {statusOption}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                </div>
+                <div className="inquiry-details">
+                  <div>
+                    <span>Adopter</span>
+                    <strong>{inquiry.name}</strong>
+                    <a href={`mailto:${inquiry.email}`}>{inquiry.email}</a>
+                    <a href={`tel:${inquiry.phone}`}>{inquiry.phone}</a>
+                  </div>
+                  <div>
+                    <span>Housing</span>
+                    <p>{inquiry.housing}</p>
+                  </div>
+                  <div>
+                    <span>Message</span>
+                    <p>{inquiry.message}</p>
+                  </div>
+                </div>
+              </article>
+            ))}
+          </div>
+        )}
+      </section>
     </section>
   );
 }
@@ -607,6 +711,7 @@ function NotFound() {
 function MyApp() {
   const [route, setRoute] = useState(parseRoute);
   const [pets, setPets] = useState([]);
+  const [inquiries, setInquiries] = useState([]);
   const [favorites, setFavorites] = useState(() => readJson(favoritesKey, []));
   const [apiStatus, setApiStatus] = useState("Loading pets from backend...");
 
@@ -655,6 +760,29 @@ function MyApp() {
     };
   }, []);
 
+  useEffect(() => {
+    let ignore = false;
+
+    async function loadInquiries() {
+      try {
+        const backendInquiries = await apiRequest("/inquiries");
+
+        if (!ignore) {
+          setInquiries(backendInquiries.map(normalizeInquiry));
+        }
+      } catch {
+        if (!ignore) {
+          setInquiries([]);
+        }
+      }
+    }
+
+    loadInquiries();
+    return () => {
+      ignore = true;
+    };
+  }, []);
+
   async function addPet(pet) {
     const createdPet = normalizePet(await apiRequest("/pets", {
       method: "POST",
@@ -665,10 +793,23 @@ function MyApp() {
   }
 
   async function addInquiry(inquiry) {
-    return apiRequest("/inquiries", {
+    const createdInquiry = normalizeInquiry(await apiRequest("/inquiries", {
       method: "POST",
       body: JSON.stringify(inquiry)
-    });
+    }));
+    setInquiries((current) => [createdInquiry, ...current]);
+    return createdInquiry;
+  }
+
+  async function updateInquiryStatus(id, status) {
+    const updatedInquiry = normalizeInquiry(await apiRequest(`/inquiries/${id}/status`, {
+      method: "PATCH",
+      body: JSON.stringify({ status })
+    }));
+    setInquiries((current) =>
+      current.map((inquiry) => (inquiry.id === id ? updatedInquiry : inquiry))
+    );
+    return updatedInquiry;
   }
 
   async function updatePetPhotos(id, imageUrls) {
@@ -685,7 +826,7 @@ function MyApp() {
   let page;
   if (route.page === "profile") page = pet ? <ProfilePage pet={pet} favorites={favorites} setFavorites={setFavorites} addInquiry={addInquiry} /> : <NotFound />;
   else if (route.page === "favorites") page = <FavoritesPage pets={pets} favoriteIds={favorites} />;
-  else if (route.page === "shelter") page = <ShelterPage pets={pets} addPet={addPet} />;
+  else if (route.page === "shelter") page = <ShelterPage pets={pets} inquiries={inquiries} addPet={addPet} updateInquiryStatus={updateInquiryStatus} />;
   else if (route.page === "photos") page = pet ? <PhotoManagerPage pet={pet} updatePetPhotos={updatePetPhotos} /> : <NotFound />;
   else page = <HomePage pets={pets} />;
 

--- a/packages/react-frontend/src/main.css
+++ b/packages/react-frontend/src/main.css
@@ -197,6 +197,10 @@ p {
   margin-bottom: 20px;
 }
 
+.section-heading.compact {
+  margin-bottom: 14px;
+}
+
 .pet-grid {
   display: grid;
   gap: 20px;
@@ -422,6 +426,96 @@ textarea {
   border-radius: 8px;
 }
 
+.inquiry-panel {
+  grid-column: 1 / -1;
+}
+
+.empty-state {
+  background: #f5f0e8;
+  border: 1px dashed rgba(38, 52, 47, 0.2);
+  border-radius: 8px;
+  color: rgba(38, 52, 47, 0.68);
+  font-weight: 700;
+  padding: 16px;
+}
+
+.inquiry-list {
+  display: grid;
+  gap: 12px;
+}
+
+.inquiry-item {
+  border: 1px solid rgba(38, 52, 47, 0.12);
+  border-radius: 8px;
+  display: grid;
+  gap: 14px;
+  padding: 16px;
+}
+
+.inquiry-heading {
+  align-items: flex-start;
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+}
+
+.inquiry-heading h3,
+.inquiry-heading p,
+.inquiry-details p {
+  margin-bottom: 0;
+}
+
+.inquiry-details {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: 0.85fr 1fr 1.2fr;
+}
+
+.inquiry-details div {
+  background: #f5f0e8;
+  border-radius: 8px;
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+  padding: 12px;
+}
+
+.inquiry-details span {
+  color: rgba(38, 52, 47, 0.56);
+  font-size: 0.76rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.inquiry-details a {
+  color: #64724f;
+  font-weight: 800;
+  overflow-wrap: anywhere;
+}
+
+.status-control {
+  align-items: end;
+  display: grid;
+  gap: 6px;
+  min-width: 150px;
+}
+
+.status-control span {
+  color: rgba(38, 52, 47, 0.56);
+  font-size: 0.76rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.status-control select {
+  background: rgba(100, 114, 79, 0.12);
+  border-color: rgba(100, 114, 79, 0.3);
+  color: #4c5f37;
+  font-weight: 800;
+  min-height: 38px;
+  text-transform: capitalize;
+}
+
 @media (max-width: 900px) {
   .hero,
   .profile-grid,
@@ -435,6 +529,10 @@ textarea {
 
   .sticky-panel {
     position: static;
+  }
+
+  .inquiry-details {
+    grid-template-columns: 1fr;
   }
 }
 


### PR DESCRIPTION
Closes #12 and #13, I decided to do both at once for convenience.

I added a shelter inquiry dashboard so staff can view the submitted adoptions inquiries. Each inquiry shows the data from mongo including the adopter name, the pet, etc.

I also added the ability for staff to change the status of each inquiry in the database, (and it updates mongo too!). In the future, it might be good to have "New" be a status that hasn't been changed, rather than one that is manually inputted.

Note: We are eventually going to want to separate all the shelter portal features into separate tabs in the portal, rather than scrolling down through all of them. This can be something we do for stretch 3.