### PR TITLE
Make pet cards fully clickable

### DIFF
--- a/cypress/e2e/user-stories.cy.js
+++ b/cypress/e2e/user-stories.cy.js
@@ -148,6 +148,13 @@ describe("final user story coverage", () => {
 
     cy.visit("/");
     cy.get("[data-cy=pet-card]").should("have.length", 2);
+    cy.contains("[data-cy=pet-card]", "Maple").click();
+    cy.location("hash").should("eq", "#/pets/pet-maple");
+    cy.get("[data-cy=pet-profile-name]").should(
+      "contain.text",
+      "Maple"
+    );
+    cy.visit("/");
 
     cy.get("[data-cy=preference-species]").select("Other");
     cy.get("[data-cy=feed-empty]").should(
@@ -191,7 +198,7 @@ describe("final user story coverage", () => {
       "contain.text",
       "Nova"
     );
-    cy.get("[data-cy=favorite-profile-link]").click();
+    cy.contains("[data-cy=favorite-pet-card]", "Nova").click();
     cy.get("[data-cy=pet-profile-name]").should(
       "contain.text",
       "Nova"

--- a/packages/react-frontend/src/MyApp.jsx
+++ b/packages/react-frontend/src/MyApp.jsx
@@ -722,9 +722,11 @@ function HomePage({
         ) : (
           <div className="pet-grid">
             {visiblePets.map((pet) => (
-              <article
+              <a
                 className="pet-card"
+                href={`#/pets/${pet.id}`}
                 key={pet.id}
+                aria-label={`View ${pet.name}'s profile`}
                 data-cy="pet-card">
                 <Photo
                   src={pet.imageUrls[0]}
@@ -744,14 +746,13 @@ function HomePage({
                   </div>
                   <p>{pet.description}</p>
                   <p className="muted">{pet.location}</p>
-                  <a
+                  <span
                     className="button dark"
-                    href={`#/pets/${pet.id}`}
                     data-cy="pet-card-link">
                     View profile
-                  </a>
+                  </span>
                 </div>
-              </article>
+              </a>
             ))}
           </div>
         )}
@@ -1039,9 +1040,11 @@ function FavoritesPage({
       ) : (
         <div className="pet-grid" data-cy="favorites-list">
           {favorites.map((pet) => (
-            <article
+            <a
               className="pet-card"
+              href={`#/pets/${pet.id}`}
               key={pet.id}
+              aria-label={`View ${pet.name}'s profile`}
               data-cy="favorite-pet-card">
               <Photo
                 src={pet.imageUrls[0]}
@@ -1052,14 +1055,13 @@ function FavoritesPage({
                 <p>
                   {pet.breed} - {pet.age}
                 </p>
-                <a
+                <span
                   className="button dark"
-                  href={`#/pets/${pet.id}`}
                   data-cy="favorite-profile-link">
                   View profile
-                </a>
+                </span>
               </div>
-            </article>
+            </a>
           ))}
         </div>
       )}

--- a/packages/react-frontend/src/main.css
+++ b/packages/react-frontend/src/main.css
@@ -203,6 +203,23 @@ p {
   overflow: hidden;
 }
 
+.pet-card {
+  cursor: pointer;
+  display: block;
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease,
+    transform 0.15s ease;
+}
+
+.pet-card:hover,
+.pet-card:focus-visible {
+  border-color: rgba(47, 111, 107, 0.35);
+  box-shadow: 0 18px 46px rgba(38, 52, 47, 0.13);
+  outline: none;
+  transform: translateY(-2px);
+}
+
 .featured-card > img {
   height: 320px;
   object-fit: cover;
@@ -252,6 +269,12 @@ p {
   aspect-ratio: 4 / 3;
   object-fit: cover;
   width: 100%;
+}
+
+.pet-card .button {
+  align-items: center;
+  display: inline-flex;
+  justify-content: center;
 }
 
 .card-body {


### PR DESCRIPTION
## Summary
- Make discovery pet cards full-card links to profile pages while preserving existing data-cy hooks
- Apply the same full-card link behavior to favorites cards
- Add hover/focus affordance and Cypress coverage for clicking card containers

## Verification
- npm run verify
- npm run test:e2e:stories
- Browser check: clicked the first pet card body/image area and landed on Clover's profile