### PR TITLE
Fix shelter photo manager layout

### DIFF
--- a/packages/react-frontend/src/MyApp.jsx
+++ b/packages/react-frontend/src/MyApp.jsx
@@ -1678,13 +1678,15 @@ function PhotoManagerPage({ pet, updatePetPhotos }) {
   }
 
   return (
-    <section className="shelter-layout">
-      <div className="panel">
-        <a className="back-link" href="#/shelter">
-          Back to shelter portal
-        </a>
-        <span className="eyebrow">Shelter photo manager</span>
-        <h1>Manage {pet.name} photos</h1>
+    <section className="shelter-layout photo-manager-layout">
+      <div className="panel photo-manager-panel">
+        <div className="photo-manager-heading">
+          <a className="back-link" href="#/shelter">
+            Back to shelter portal
+          </a>
+          <span className="eyebrow">Shelter photo manager</span>
+          <h1>Manage {pet.name} photos</h1>
+        </div>
         {status ? (
           <div
             className="success"
@@ -1745,10 +1747,10 @@ function PhotoManagerPage({ pet, updatePetPhotos }) {
           </div>
         </form>
       </div>
-      <aside className="panel">
+      <aside className="panel photo-gallery-panel">
         <h2>Current gallery</h2>
         <div
-          className="preview-grid"
+          className="preview-grid photo-manager-preview-list"
           data-cy="managed-photo-preview-list">
           {previewUrls.map((url, index) => (
             <Photo

--- a/packages/react-frontend/src/main.css
+++ b/packages/react-frontend/src/main.css
@@ -39,6 +39,10 @@ img {
   display: block;
 }
 
+[hidden] {
+  display: none !important;
+}
+
 .app-shell {
   min-height: 100vh;
 }
@@ -527,13 +531,60 @@ textarea {
   padding: 14px;
 }
 
+.photo-manager-layout {
+  grid-template-columns: minmax(0, 1fr) minmax(320px, 0.72fr);
+  max-width: 1320px;
+}
+
+.photo-manager-heading {
+  display: grid;
+  gap: 8px;
+  margin-bottom: 22px;
+}
+
+.photo-manager-heading .back-link {
+  display: block;
+  margin-bottom: 4px;
+}
+
+.photo-manager-heading h1 {
+  font-size: clamp(2rem, 4vw, 3.2rem);
+  line-height: 1.04;
+  margin-bottom: 0;
+}
+
+.photo-manager-panel {
+  align-self: start;
+}
+
+.photo-manager-panel .form-grid {
+  gap: 18px;
+}
+
+.photo-manager-panel .actions {
+  flex-wrap: wrap;
+}
+
 .photo-row {
   display: flex;
   gap: 8px;
 }
 
 .photo-row input {
+  flex: 1 1 auto;
   min-width: 0;
+}
+
+.photo-row button {
+  flex: 0 0 auto;
+}
+
+.photo-gallery-panel {
+  align-self: start;
+}
+
+.photo-gallery-panel h2 {
+  margin-bottom: 18px;
 }
 
 .profile-list {
@@ -567,6 +618,21 @@ textarea {
 .preview-img {
   aspect-ratio: 1;
   border-radius: 8px;
+}
+
+.photo-manager-preview-list {
+  grid-template-columns: 1fr;
+}
+
+.photo-manager-preview-list .preview-img {
+  aspect-ratio: 4 / 3;
+  background: #eef3ed;
+  border: 1px solid rgba(38, 52, 47, 0.1);
+  display: block;
+  height: auto;
+  max-width: 100%;
+  object-fit: contain;
+  width: 100%;
 }
 
 .inquiry-panel {


### PR DESCRIPTION
## Summary
- separate the photo manager back link, eyebrow, and title so they do not overlap
- resize the manager heading and make the form panel hug its content
- constrain gallery preview images to the gallery card and preserve hidden Cypress image hooks

## Validation
- npm run verify
- npm run test:e2e:stories
- Browser visual checks at desktop and mobile widths